### PR TITLE
fix: reset ap/bp/cp at phi==0 (thread-order-dependent stale-buffer bug)

### DIFF
--- a/nanoBragg.c
+++ b/nanoBragg.c
@@ -2787,6 +2787,16 @@ if(! debug_printed_thread) {
                                     rotate_axis(b0,bp,spindle_vector,phi);
                                     rotate_axis(c0,cp,spindle_vector,phi);
                                 }
+                                else
+                                {
+                                    /* phi==0: skip the (identity) rotation, but reset ap/bp/cp to the
+                                       unrotated cell vectors. They are firstprivate and persist across
+                                       pixels, so without this they reuse the previous iteration's rotated
+                                       values (a thread-order-dependent stale read). Mirrors the mosaic reset below. */
+                                    ap[1]=a0[1];ap[2]=a0[2];ap[3]=a0[3];
+                                    bp[1]=b0[1];bp[2]=b0[2];bp[3]=b0[3];
+                                    cp[1]=c0[1];cp[2]=c0[2];cp[3]=c0[3];
+                                }
 
                                 /* enumerate mosaic domains */
                                 for(mos_tic=0;mos_tic<mosaic_domains;++mos_tic)


### PR DESCRIPTION
## Summary
At the phi==0 sample the spindle rotation is skipped (`if(phi != 0.0)`), but
ap/bp/cp are declared outside the pixel loop (OpenMP firstprivate), so they
still hold the *previous* pixel's rotated orientation instead of the unrotated
a0/b0/c0. Intensity is inflated whenever phi0==0 (the default) with phisteps>1.

## Why it's a bug, not just a divergence
The stale buffer makes the result depend on **thread count** — which a physics
result must not. Same config, varying OMP_NUM_THREADS:
- up to ~28% per-pixel difference (5 distinct md5s at threads 1/2/4/8/24)
- ~14% total-intensity shift at 1 thread vs the intended phi==0 = a0 orientation

Aggregates wash out (~corr 1.0), which is why it hid for years. Independently
confirmed: `-phi 1e-9` (phi never exactly 0) matches to float-eps at all phisteps.

## Fix
Keep the fast phi==0 path (skip the rotation) and add an `else` resetting
ap/bp/cp = a0/b0/c0 — mirroring the mosaic reset just below. rotate_axis(phi=0)
is the identity, so this is bit-exact with unconditionally rotating and
unchanged for all phi!=0.

## Scope
nanoBragg.c, +10 lines, one hunk. No API/CLI change.
Proposal for your review — happy to switch to remove-guard form (byte-identical).
